### PR TITLE
Simplify error handling and clean up code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ travis-ci = { repository = "roosta/i3wsr" }
 
 [dependencies]
 xcb = "0.8"
+exitfailure = "0.5.1"
+failure = "0.1.2"
+failure_derive = "0.1.2"
 
 [dependencies.i3ipc]
 version = "0.8.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,11 @@ pub fn update_tree(x_conn: &xcb::Connection, i3_conn: &mut I3Connection) -> Resu
             .to_owned()
             .ok_or(format!("Failed to get workspace name for workspace: {:#?}", workspace))?;
         let old_split: Vec<&str> = old.split(' ').collect();
-        let new = format!("{} {}", old_split[0], classes);
+        let new = if classes.is_empty() {
+            format!("{}", old_split[0])
+        } else {
+            format!("{} {}", old_split[0], classes)
+        };
         if old != new {
             let command = format!("rename workspace \"{}\" to \"{}\"", old, new);
             i3_conn.run_command(&command)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,17 @@
-extern crate i3ipc;
 extern crate xcb;
-
-use i3ipc::event::inner::WindowChange;
-use i3ipc::event::inner::WorkspaceChange;
-use i3ipc::event::WindowEventInfo;
-use i3ipc::event::WorkspaceEventInfo;
-use i3ipc::reply::Node;
-use i3ipc::reply::NodeType;
-use i3ipc::I3Connection;
-use std::error::Error;
 use xcb::xproto;
+
+extern crate i3ipc;
+use i3ipc::{
+    event::{
+        inner::{WindowChange, WorkspaceChange},
+        WindowEventInfo, WorkspaceEventInfo,
+    },
+    reply::{Node, NodeType},
+    I3Connection,
+};
+
+use std::error::Error;
 
 /// Return the window class based on id.
 /// Source: https://stackoverflow.com/questions/44833160/how-do-i-get-the-x-window-class-given-a-window-id-with-rust-xcb

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,12 +34,12 @@ fn main() {
     for event in listener.listen() {
         match event {
             Ok(Event::WindowEvent(e)) => {
-                if let Err(error) = i3wsr::handle_window_event(e, &x_conn, &mut i3_conn) {
+                if let Err(error) = i3wsr::handle_window_event(&e, &x_conn, &mut i3_conn) {
                     eprintln!("handle_window_event error: {}", error);
                 }
             }
             Ok(Event::WorkspaceEvent(e)) => {
-                if let Err(error) = i3wsr::handle_ws_event(e, &x_conn, &mut i3_conn) {
+                if let Err(error) = i3wsr::handle_ws_event(&e, &x_conn, &mut i3_conn) {
                     eprintln!("handle_ws_event error: {}", error);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,20 @@
 extern crate i3ipc;
-extern crate i3wsr;
+use i3ipc::{event::Event, I3Connection, I3EventListener, Subscription};
+
 extern crate xcb;
-use i3ipc::event::Event;
-use i3ipc::I3Connection;
-use i3ipc::I3EventListener;
-use i3ipc::Subscription;
-use std::process;
+
+extern crate i3wsr;
+
+use std::{fmt::Debug, process::exit};
 
 /// Why? cause I'm learning. Also lets me handle these spesific errors which
 /// should exit the program
-fn unwrap_connection<T, E: ::std::fmt::Debug>(obj: Result<T, E>) -> T {
+fn unwrap_connection<T, E: Debug>(obj: Result<T, E>) -> T {
     match obj {
         Ok(val) => val,
         Err(e) => {
             eprintln!("Connection error: {:?}", e);
-            process::exit(1);
+            exit(1);
         }
     }
 }
@@ -28,7 +28,7 @@ fn main() {
 
     if let Err(error) = i3wsr::update_tree(&x_conn, &mut i3_conn) {
         eprintln!("Failed initial tree update with error: {}", error);
-        process::exit(1);
+        exit(1);
     }
 
     for event in listener.listen() {
@@ -45,7 +45,7 @@ fn main() {
             }
             Err(e) => {
                 eprintln!("Error: {}", e);
-                process::exit(1);
+                exit(1);
             }
             _ => (),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 extern crate i3ipc;
 extern crate i3wsr;
 extern crate xcb;
-use i3ipc::I3EventListener;
-use std::process;
-use i3ipc::Subscription;
 use i3ipc::event::Event;
 use i3ipc::I3Connection;
+use i3ipc::I3EventListener;
+use i3ipc::Subscription;
+use std::process;
 
 /// Why? cause I'm learning. Also lets me handle these spesific errors which
 /// should exit the program
@@ -37,17 +37,17 @@ fn main() {
                 if let Err(error) = i3wsr::handle_window_event(e, &x_conn, &mut i3_conn) {
                     eprintln!("handle_window_event error: {}", error);
                 }
-            },
+            }
             Ok(Event::WorkspaceEvent(e)) => {
                 if let Err(error) = i3wsr::handle_ws_event(e, &x_conn, &mut i3_conn) {
                     eprintln!("handle_ws_event error: {}", error);
                 }
-            },
+            }
             Err(e) => {
                 eprintln!("Error: {}", e);
                 process::exit(1);
-            },
-            _ => ()
+            }
+            _ => (),
         }
     }
 }


### PR DESCRIPTION
Many of these changes are very opinionated, so feel free to question any of them and I can make some changes.

I added [failure](https://github.com/rust-lang-nursery/failure/) as a dependency to make error creation and handling simpler. Most of the errors return by the other libraries already implement `Debug` AND `Display`. To benefit from that, I also added [exitfailure](https://github.com/tismith/exitfailure), which uses `Display` instead of `Debug` when `main` returns an error. Now we should get nice error messages without having to worry about it.

The main motivation for forking your project was that I loved it but was a bit annoyed by how empty workspaces had a trailing space in their names. Maybe I went too far, hahah!