### PR TITLE
Add support to icons based on class

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ failure = "0.1.2"
 failure_derive = "0.1.2"
 lazy_static = "1.4.0"
 clap = "2.33.0"
+toml = "0.5.4"
+serde = { version = "1.0", features = ["derive"] }
 
 [dependencies.i3ipc]
 version = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ xcb = "0.8"
 exitfailure = "0.5.1"
 failure = "0.1.2"
 failure_derive = "0.1.2"
+lazy_static = "1.4.0"
+clap = "2.33.0"
 
 [dependencies.i3ipc]
 version = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,52 @@ Another option is to put something like this in your i3 config
 exec_always --no-startup-id exec $HOME/.cargo/bin/i3wsr
 ```
 
+### Options
+
+You can configure icons for the respective classes, a very basic preset for font-awesome is configured, to enable it use the option `--icons awesome` (requires font-awesome to be installed).
+
+If you have icons and don't want the names to be displayed, you can use the `--no-names` flag.
+
+For further customization, use the `--config path_to_file.toml` option. The `toml` file has to fields, `icons` to assign icons to classes, and `aliases` to assign alternative names to be displayed.
+
+Example config can be found in `assets/example_config.toml`
+
+```toml
+[icons]
+# font awesome
+TelegramDesktop = ""
+Firefox = ""
+Alacritty = ""
+Thunderbird = ""
+# smile emoji
+MyNiceProgram = "😛"
+
+[aliases]
+TelegramDesktop = "Telegram"
+"Org.gnome.Nautilus" = "Nautilus"
+```
+
+For an overview of available options
+
+```shell
+$ i3wsr -h
+i3wsr - i3 workspace renamer 1.1.1
+Daniel Berg <mail@roosta.sh>
+
+USAGE:
+    i3wsr [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help        Prints help information
+        --no-names    Set to no to display only icons (if available)
+    -V, --version     Prints version information
+
+OPTIONS:
+    -c, --config <config>    Path to toml config file
+        --icons <icons>      Sets icons to be used [possible values: awesome]
+
+```
+
 ## Configuration
 
 This program depends on numbered workspaces, since we're constantly changing the

--- a/assets/example_config.toml
+++ b/assets/example_config.toml
@@ -7,5 +7,6 @@ Thunderbird = ""
 # smile emoji
 MyNiceProgram = "😛"
 
-[classes]
+[aliases]
 TelegramDesktop = "Telegram"
+"Org.gnome.Nautilus" = "Nautilus"

--- a/assets/example_config.toml
+++ b/assets/example_config.toml
@@ -1,0 +1,11 @@
+[icons]
+# font awesome
+TelegramDesktop = ""
+Firefox = ""
+Alacritty = ""
+Thunderbird = ""
+# smile emoji
+MyNiceProgram = "😛"
+
+[classes]
+TelegramDesktop = "Telegram"

--- a/assets/example_icons.toml
+++ b/assets/example_icons.toml
@@ -1,0 +1,4 @@
+[icons]
+Firefox = "f269"
+TelegramDesktop = "f2c6"
+Alacritty = "f120"

--- a/assets/example_icons.toml
+++ b/assets/example_icons.toml
@@ -1,4 +1,0 @@
-[icons]
-Firefox = "f269"
-TelegramDesktop = "f2c6"
-Alacritty = "f120"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,19 +5,27 @@ use serde::Deserialize;
 use failure::Error;
 
 lazy_static! {
-    pub static ref EMPTY_CLASSES_MAP: Map<String, String> = Map::new();
+    pub static ref EMPTY_ALIASES_MAP: Map<String, String> = Map::new();
 }
 
 #[derive(Deserialize)]
-pub struct TomlConfig {
-    pub icons: Map<String, char>,
-    pub classes: Map<String, String>,
+struct TomlDeserializableConfig {
+    icons: Option<Map<String, char>>,
+    aliases: Option<Map<String, String>>,
 }
 
-pub fn read_toml_config(filename: &str) -> Result<TomlConfig, Error> {
+pub struct Config {
+    pub icons: Map<String, char>,
+    pub aliases: Map<String, String>,
+}
+
+pub fn read_toml_config(filename: &str) -> Result<Config, Error> {
     let mut file = File::open(filename)?;
     let mut buffer = String::new();
     file.read_to_string(&mut buffer)?;
-    let config: TomlConfig = toml::from_str(&buffer)?;
-    Ok(config)
+    let config: TomlDeserializableConfig = toml::from_str(&buffer)?;
+    Ok(Config {
+        icons: config.icons.unwrap_or(super::icons::NONE.clone()),
+        aliases: config.aliases.unwrap_or(EMPTY_ALIASES_MAP.clone()),
+    })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap as Map;
+use std::fs::File;
+use std::io::Read;
+use serde::Deserialize;
+use failure::Error;
+
+lazy_static! {
+    pub static ref EMPTY_CLASSES_MAP: Map<String, String> = Map::new();
+}
+
+#[derive(Deserialize)]
+pub struct TomlConfig {
+    pub icons: Map<String, char>,
+    pub classes: Map<String, String>,
+}
+
+pub fn read_toml_config(filename: &str) -> Result<TomlConfig, Error> {
+    let mut file = File::open(filename)?;
+    let mut buffer = String::new();
+    file.read_to_string(&mut buffer)?;
+    let config: TomlConfig = toml::from_str(&buffer)?;
+    Ok(config)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,24 +8,26 @@ lazy_static! {
     pub static ref EMPTY_ALIASES_MAP: Map<String, String> = Map::new();
 }
 
+#[serde(default)]
 #[derive(Deserialize)]
-struct TomlDeserializableConfig {
-    icons: Option<Map<String, char>>,
-    aliases: Option<Map<String, String>>,
-}
-
 pub struct Config {
     pub icons: Map<String, char>,
     pub aliases: Map<String, String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            icons: super::icons::NONE.clone(),
+            aliases: EMPTY_ALIASES_MAP.clone(),
+        }
+    }
 }
 
 pub fn read_toml_config(filename: &str) -> Result<Config, Error> {
     let mut file = File::open(filename)?;
     let mut buffer = String::new();
     file.read_to_string(&mut buffer)?;
-    let config: TomlDeserializableConfig = toml::from_str(&buffer)?;
-    Ok(Config {
-        icons: config.icons.unwrap_or(super::icons::NONE.clone()),
-        aliases: config.aliases.unwrap_or(EMPTY_ALIASES_MAP.clone()),
-    })
+    let config: Config = toml::from_str(&buffer)?;
+    Ok(config)
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,6 +1,17 @@
 use std::collections::HashMap as Map;
+use std::fs::File;
+use std::io::Read;
+use std::char;
+use failure::Error;
 
-// Source: https://github.com/greshake/i3status-rust/blob/master/src/icons.rs
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct TomlConfig {
+    icons: Map<String, String>,
+}
+
+// taken from https://github.com/greshake/i3status-rust/blob/master/src/icons.rs
 macro_rules! map_to_owned (
     { $($key:expr => $value:expr),+ } => {
         {
@@ -13,20 +24,54 @@ macro_rules! map_to_owned (
      };
 );
 
-// Source: https://github.com/gluons/Font-Awesome-Icon-Chars
 lazy_static! {
     pub static ref AWESOME: Map<String, String> = map_to_owned! {
-        "Firefox" => "\u{f269} ",
-        "TelegramDesktop" => "\u{f2c6} ",
-        "Alacritty" => "\u{f120} ",
-        "Thunderbird" => "\u{f0e0} "
+        "Firefox" => "\u{f269}",
+        "TelegramDesktop" => "\u{f2c6}",
+        "Alacritty" => "\u{f120}",
+        "Thunderbird" => "\u{f0e0}",
+        "KeeWeb" => "\u{f023}",
+        "Org.gnome.Nautilus" => "\u{f07b}",
+        "Evince" => "\u{f1c1}"
     };
+
+    pub static ref NONE: Map<String, String> = Map::new();
 }
 
-
-pub fn get_icons(name: &str) -> Option<Map<String, String>> {
-    match name {
-        "awesome" => Some(AWESOME.clone()),
-        _ => None,
+pub fn get_icons(name: &str) -> Map<String, String> {
+    if name.contains(".toml") {
+        return match read_toml_icons(name) {
+            Ok(icons) => icons,
+            Err(e) => {
+                println!("Could not read icons {}", e);
+                NONE.clone()
+            }
+        }
     }
+    match name {
+        "awesome" => AWESOME.clone(),
+        _ => NONE.clone(),
+    }
+}
+
+pub fn read_toml_icons(filename: &str) -> Result<Map<String, String>, Error> {
+    let mut file = File::open(filename)?;
+    let mut buffer = String::new();
+    file.read_to_string(&mut buffer)?;
+    let config: TomlConfig = toml::from_str(&buffer)?;
+    let icons = {
+        let mut m = Map::new();
+        for (key, value) in &config.icons {
+            let new_value = match char::from_u32(u32::from_str_radix(value, 16)?) {
+                Some(value) => value.to_string(),
+                None => {
+                    println!("Could not parse icon {}", value);
+                    "".to_string()
+                },
+            };
+            m.insert(key.to_string(), new_value);
+        }
+        m
+    };
+    Ok(icons)
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap as Map;
+
+// Source: https://github.com/greshake/i3status-rust/blob/master/src/icons.rs
+macro_rules! map_to_owned (
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key.to_owned(), $value.to_owned());
+            )+
+            m
+        }
+     };
+);
+
+// Source: https://github.com/gluons/Font-Awesome-Icon-Chars
+lazy_static! {
+    pub static ref AWESOME: Map<String, String> = map_to_owned! {
+        "Firefox" => "\u{f269} ",
+        "TelegramDesktop" => "\u{f2c6} ",
+        "Alacritty" => "\u{f120} ",
+        "Thunderbird" => "\u{f0e0} "
+    };
+}
+
+
+pub fn get_icons(name: &str) -> Option<Map<String, String>> {
+    match name {
+        "awesome" => Some(AWESOME.clone()),
+        _ => None,
+    }
+}

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,15 +1,5 @@
 use std::collections::HashMap as Map;
-use std::fs::File;
-use std::io::Read;
 use std::char;
-use failure::Error;
-
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-struct TomlConfig {
-    icons: Map<String, String>,
-}
 
 // taken from https://github.com/greshake/i3status-rust/blob/master/src/icons.rs
 macro_rules! map_to_owned (
@@ -25,53 +15,22 @@ macro_rules! map_to_owned (
 );
 
 lazy_static! {
-    pub static ref AWESOME: Map<String, String> = map_to_owned! {
-        "Firefox" => "\u{f269}",
-        "TelegramDesktop" => "\u{f2c6}",
-        "Alacritty" => "\u{f120}",
-        "Thunderbird" => "\u{f0e0}",
-        "KeeWeb" => "\u{f023}",
-        "Org.gnome.Nautilus" => "\u{f07b}",
-        "Evince" => "\u{f1c1}"
+    pub static ref AWESOME: Map<String, char> = map_to_owned! {
+        "Firefox" => '',
+        "TelegramDesktop" => '',
+        "Alacritty" => '',
+        "Thunderbird" => '',
+        "KeeWeb" => '',
+        "Org.gnome.Nautilus" => '',
+        "Evince" => ''
     };
 
-    pub static ref NONE: Map<String, String> = Map::new();
+    pub static ref NONE: Map<String, char> = Map::new();
 }
 
-pub fn get_icons(name: &str) -> Map<String, String> {
-    if name.contains(".toml") {
-        return match read_toml_icons(name) {
-            Ok(icons) => icons,
-            Err(e) => {
-                println!("Could not read icons {}", e);
-                NONE.clone()
-            }
-        }
-    }
+pub fn get_icons(name: &str) -> Map<String, char> {
     match name {
         "awesome" => AWESOME.clone(),
         _ => NONE.clone(),
     }
-}
-
-pub fn read_toml_icons(filename: &str) -> Result<Map<String, String>, Error> {
-    let mut file = File::open(filename)?;
-    let mut buffer = String::new();
-    file.read_to_string(&mut buffer)?;
-    let config: TomlConfig = toml::from_str(&buffer)?;
-    let icons = {
-        let mut m = Map::new();
-        for (key, value) in &config.icons {
-            let new_value = match char::from_u32(u32::from_str_radix(value, 16)?) {
-                Some(value) => value.to_string(),
-                None => {
-                    println!("Could not parse icon {}", value);
-                    "".to_string()
-                },
-            };
-            m.insert(key.to_string(), new_value);
-        }
-        m
-    };
-    Ok(icons)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,15 @@ extern crate serde;
 
 #[macro_use]
 extern crate lazy_static;
-pub mod icons;
 
 extern crate toml;
 
+pub mod icons;
+pub mod config;
+
 pub struct Options {
-    pub icons: Map<String, String>,
+    pub icons: Map<String, char>,
+    pub classes: Map<String, String>,
     pub names: bool,
 }
 
@@ -72,15 +75,19 @@ fn get_class(conn: &xcb::Connection, id: u32, options: &Options) -> Result<Strin
     let mut results = result.split('\0');
     results.next_back();
     let mut results_with_icons = results.map(|class| {
+        let class_display_name = match options.classes.get(class) {
+            Some(alias) => alias,
+            None => class,
+        };
         match options.icons.get(class) {
             Some(icon) => {
                 if options.names {
-                    format!(" {} {} ", icon, class)
+                    format!(" {} {} ", icon, class_display_name)
                 } else {
                     format!(" {} ", icon)
                 }
             }
-            None => format!(" {} ", class),
+            None => format!(" {} ", class_display_name),
         }
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod config;
 
 pub struct Options {
     pub icons: Map<String, char>,
-    pub classes: Map<String, String>,
+    pub aliases: Map<String, String>,
     pub names: bool,
 }
 
@@ -75,7 +75,7 @@ fn get_class(conn: &xcb::Connection, id: u32, options: &Options) -> Result<Strin
     let mut results = result.split('\0');
     results.next_back();
     let mut results_with_icons = results.map(|class| {
-        let class_display_name = match options.classes.get(class) {
+        let class_display_name = match options.aliases.get(class) {
             Some(alias) => alias,
             None => class,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,17 +34,20 @@ fn main() -> Result<(), ExitFailure> {
     let no_names = matches.is_present("no-names");
     let options = match matches.value_of("config") {
         Some(filename) => {
-            let file_config = i3wsr::config::read_toml_config(filename).unwrap();
+            let file_config = match i3wsr::config::read_toml_config(filename) {
+                Ok(config) => config,
+                Err(e) => panic!("Could not parse config file\n {}", e)
+            };
             i3wsr::Options {
                 icons: file_config.icons.into_iter().chain(i3wsr::icons::get_icons(&icons)).collect(),
-                classes: file_config.classes,
+                aliases: file_config.aliases,
                 names: !no_names,
             }
         },
         None => {
             i3wsr::Options {
                 icons: i3wsr::icons::get_icons(&icons),
-                classes: i3wsr::config::EMPTY_CLASSES_MAP.clone(),
+                aliases: i3wsr::config::EMPTY_ALIASES_MAP.clone(),
                 names: !no_names,
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,14 @@ extern crate i3wsr;
 extern crate exitfailure;
 use exitfailure::ExitFailure;
 
+#[macro_use]
 extern crate clap;
 use clap::{App, Arg};
 
 fn main() -> Result<(), ExitFailure> {
     let matches = App::new("i3wsr - i3 workspace renamer")
-       .version("1.0")
-       .author("Daniel Berg")
+       .version(crate_version!())
+       .author(crate_authors!(",\n"))
         .arg(Arg::with_name("icons")
             .long("icons")
             .help("Sets icons to be used")

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,24 +8,47 @@ extern crate i3wsr;
 extern crate exitfailure;
 use exitfailure::ExitFailure;
 
+extern crate clap;
+use clap::{App, Arg};
+use i3wsr::Options;
+
 fn main() -> Result<(), ExitFailure> {
+    let matches = App::new("i3wsr - i3 workspace renamer")
+       .version("1.0")
+       .author("Daniel Berg")
+        .arg(Arg::with_name("icons")
+            .long("icons")
+            .help("Sets icons to be used (e.g. awesome)")
+            .takes_value(true))
+        .arg(Arg::with_name("no-names")
+            .long("no-names")
+            .help("Set to no to display only icons (if available)"))
+       .get_matches();
+
+    let icons = matches.value_of("icons").unwrap_or("").to_string();
+    let no_names = matches.is_present("no-names");
+    let options = Options {
+        icons: icons,
+        names: !no_names,
+    };
+
     let mut listener = I3EventListener::connect()?;
     let subs = [Subscription::Window, Subscription::Workspace];
     listener.subscribe(&subs)?;
 
     let (x_conn, _) = xcb::Connection::connect(None)?;
     let mut i3_conn = I3Connection::connect()?;
-    i3wsr::update_tree(&x_conn, &mut i3_conn)?;
+    i3wsr::update_tree(&x_conn, &mut i3_conn, &options)?;
 
     for event in listener.listen() {
         match event? {
             Event::WindowEvent(e) => {
-                if let Err(error) = i3wsr::handle_window_event(&e, &x_conn, &mut i3_conn) {
+                if let Err(error) = i3wsr::handle_window_event(&e, &x_conn, &mut i3_conn, &options) {
                     eprintln!("handle_window_event error: {}", error);
                 }
             }
             Event::WorkspaceEvent(e) => {
-                if let Err(error) = i3wsr::handle_ws_event(&e, &x_conn, &mut i3_conn) {
+                if let Err(error) = i3wsr::handle_ws_event(&e, &x_conn, &mut i3_conn, &options) {
                     eprintln!("handle_ws_event error: {}", error);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), ExitFailure> {
        .author("Daniel Berg")
         .arg(Arg::with_name("icons")
             .long("icons")
-            .help("Sets icons to be used (e.g. awesome)")
+            .help("Sets icons to be used (e.g. awesome (requires font-awesome) or path to toml file)")
             .takes_value(true))
         .arg(Arg::with_name("no-names")
             .long("no-names")
@@ -28,7 +28,7 @@ fn main() -> Result<(), ExitFailure> {
     let icons = matches.value_of("icons").unwrap_or("").to_string();
     let no_names = matches.is_present("no-names");
     let options = Options {
-        icons: icons,
+        icons: i3wsr::icons::get_icons(&icons),
         names: !no_names,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use exitfailure::ExitFailure;
 
 extern crate clap;
 use clap::{App, Arg};
-use i3wsr::Options;
 
 fn main() -> Result<(), ExitFailure> {
     let matches = App::new("i3wsr - i3 workspace renamer")
@@ -18,18 +17,37 @@ fn main() -> Result<(), ExitFailure> {
        .author("Daniel Berg")
         .arg(Arg::with_name("icons")
             .long("icons")
-            .help("Sets icons to be used (e.g. awesome (requires font-awesome) or path to toml file)")
+            .help("Sets icons to be used")
+            .possible_values(&["awesome"])
             .takes_value(true))
         .arg(Arg::with_name("no-names")
             .long("no-names")
             .help("Set to no to display only icons (if available)"))
+        .arg(Arg::with_name("config")
+            .long("config")
+            .short("c")
+            .help("Path to toml config file")
+            .takes_value(true))
        .get_matches();
 
-    let icons = matches.value_of("icons").unwrap_or("").to_string();
+    let icons = matches.value_of("icons").unwrap_or("");
     let no_names = matches.is_present("no-names");
-    let options = Options {
-        icons: i3wsr::icons::get_icons(&icons),
-        names: !no_names,
+    let options = match matches.value_of("config") {
+        Some(filename) => {
+            let file_config = i3wsr::config::read_toml_config(filename).unwrap();
+            i3wsr::Options {
+                icons: file_config.icons.into_iter().chain(i3wsr::icons::get_icons(&icons)).collect(),
+                classes: file_config.classes,
+                names: !no_names,
+            }
+        },
+        None => {
+            i3wsr::Options {
+                icons: i3wsr::icons::get_icons(&icons),
+                classes: i3wsr::config::EMPTY_CLASSES_MAP.clone(),
+                names: !no_names,
+            }
+        }
     };
 
     let mut listener = I3EventListener::connect()?;


### PR DESCRIPTION
Hi @roosta, first of all thanks for the project, I have been using it since I started using i3 three weeks ago hehe. I wanted to play around with how to customize things, and I added this functionality to enable icons alongside the classes.
It can be statically put in the code or loaded through a `toml` file. I put for now just a minimal set as an example for font awesome (both in `toml` and in the code).
I would love to know if you are interested in adding this functionality and I am happy to discuss it.

Here is a screenshot with how it looks using font awesome.
![image](https://user-images.githubusercontent.com/7076690/68014474-00c65980-fc90-11e9-9a4d-4648305220e9.png)
