### PR TITLE
Added tagging for swap to previous focused window

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,25 @@ pub fn handle_window_event(
         WindowChange::New | WindowChange::Close | WindowChange::Move => {
             update_tree(x_conn, i3_conn, options)?;
         }
+        WindowChange::Focus => {
+            last_focus_mark(i3_conn)?;
+        }
         _ => (),
     }
+    Ok(())
+}
+
+
+
+pub fn last_focus_mark(i3_conn: &mut I3Connection) -> Result<(), Error> {
+
+
+    i3_conn.run_command("[con_mark=_current] mark _last")?;
+    
+    
+    i3_conn.run_command("mark _current")?;
+    
+
     Ok(())
 }
 


### PR DESCRIPTION
This might be a bit of a dirty hack, but I added a small sub-function that fires on window focus change. It uses i3's default behavior of only allowing a tag to exist once across all windows, and ensures that the current focused window is tagged as _current and the previous focused window is tagged as _last.

This can be used with a keybind in i3's config to jump focus to the last focused window.

Ex: bindsym $mod+Shift+y exec i3-msg [con_mark=_last] focus

This works across workspaces as well as in the current view. 