### PR TITLE
fix example config spelling in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ TelegramDesktop = "Telegram"
 "Org.gnome.Nautilus" = "Nautilus"
 
 [general]
-seperator = ""
+separator = ""
 ```
 
 For an overview of available options


### PR DESCRIPTION
fix "seperator" spelling in `README.md`