### PR TITLE
WM_INSTANCE takes precedence over WM_CLASS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,16 @@ fn get_class(conn: &xcb::Connection, id: u32, options: &Options) -> Result<Strin
 
     let result = String::from_utf8(buf)?;
     let mut results = result.split('\0');
-    results.next_back();
+    let wm_instance = results.next().unwrap();
     let mut results_with_icons = results.map(|class| {
         let class_display_name = match options.aliases.get(class) {
             Some(alias) => alias,
             None => class,
         };
+        let mut class = class;
+        if options.icons.contains_key(wm_instance) {
+                class = wm_instance;
+        }
         match options.icons.get(class) {
             Some(icon) => {
                 if options.names {
@@ -104,7 +108,7 @@ fn get_class(conn: &xcb::Connection, id: u32, options: &Options) -> Result<Strin
     });
 
     Ok(results_with_icons
-       .next_back()
+       .next()
        .ok_or_else(|| LookupError::WindowClass(id))?
        .to_string())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,15 +85,19 @@ fn get_class(conn: &xcb::Connection, id: u32, options: &Options) -> Result<Strin
 
     let result = String::from_utf8(buf)?;
     let mut results = result.split('\0');
-    let wm_instance = results.next().unwrap();
+    let wm_instance = match results.next() {
+        Some(instance) => instance,
+        None => "",
+    };
     let mut results_with_icons = results.map(|class| {
-        let class_display_name = match options.aliases.get(class) {
+        let mut class_display_name = match options.aliases.get(class) {
             Some(alias) => alias,
             None => class,
         };
         let mut class = class;
         if options.icons.contains_key(wm_instance) {
                 class = wm_instance;
+                class_display_name = wm_instance;
         }
         match options.icons.get(class) {
             Some(icon) => {


### PR DESCRIPTION
Disclaimer: I never worked with rust before so I might have butchered the implementation but it does work. If I follow the code correctly, this PR will check if `WM_INSTANCE` is present in the config file and use that to match the icon. If no match is found it will still use `WM_CLASS`. But I'm not 100% sure of this as I am not sure I quite understand the `Ok()` return used here.

My goal here is to allow differentiating `WM_INSTANCE` from `WM_CLASS` and having it take precedence since `WM_INSTANCE` is usually more specific as far as I know. Where this comes up for me is when using browser web-apps for instance by running `chromium --app="https://web.whatsapp.com"`. This PR allows the following behaviour:
![image](https://user-images.githubusercontent.com/31730729/76714692-ebc30200-6728-11ea-819b-78c32eac434b.png)
with both icons coming from the same `WM_CLASS` but different `WM_INSTANCE`.
Feel free to adapt to rust coding conventions as I have no idea what I'm doing.