### PR TITLE
Fix config location typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can take this a bit further by using a bar that trims the workspace number a
 Configuration for i3wsr can be done using cmd flags, or a config file. A config
 file allows for more nuanced settings, and is required to configure icons and
 aliases. By default i3wsr looks for the config file at
-`$XDG_HOME/.config/i3swr/config.toml` or `$XDG_CONFIG_HOME/i3swr/config.toml`.
+`$XDG_HOME/.config/i3wsr/config.toml` or `$XDG_CONFIG_HOME/i3wsr/config.toml`.
 To specify another path, pass it to the `--config` option on invocation:
 ```bash
 i3wsr --config ~/my_config.toml


### PR DESCRIPTION
The default config path in the readme has a typo.