### PR TITLE
added WindowChange::Title event to handle_window_event.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ pub fn handle_window_event(
     res: &Vec<regex::Point>,
 ) -> Result<(), Error> {
     match e.change {
-        WindowChange::New | WindowChange::Close | WindowChange::Move => {
+        WindowChange::New | WindowChange::Close | WindowChange::Move | WindowChange::Title => {
             update_tree(x_conn, i3_conn, config, res)?;
         }
         _ => (),


### PR DESCRIPTION
Hi.
Some windows (like media player, browser) dynamically change their title. So the workspace name would be out of date without capturing change title events when `wm_property = "name"`

before adding title change event:
![image](https://user-images.githubusercontent.com/50653293/221384295-1c037365-d716-45cd-9dbf-db55ac072120.png)

after adding title change event:
![image](https://user-images.githubusercontent.com/50653293/221384310-df9b1910-ec09-4a5b-bee1-362c1c327d95.png)
