### PR TITLE
Fix potential injection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,10 @@ fn get_split_char(config: &Config) -> char {
         .unwrap_or(' ')
 }
 
+fn escape_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 fn format_workspace_name(initial: &str, titles: &str, split_at: char, config: &Config) -> String {
     let mut new = String::from(initial);
 
@@ -341,7 +345,11 @@ pub fn update_tree(
 
         // Only send command if name changed
         if old != &new {
-            let command = format!("rename workspace \"{}\" to \"{}\"", old, new);
+            let command = format!(
+                "rename workspace \"{}\" to \"{}\"",
+                escape_string(old),
+                escape_string(&new)
+            );
             if VERBOSE.load(Ordering::Relaxed) {
                 println!("{} {}", "[COMMAND]".blue(), command);
                 if let Some(output) = &workspace.output {
@@ -486,6 +494,14 @@ mod tests {
         // Test with empty string
         config.set_general("split_at".to_string(), "".to_string());
         assert_eq!(super::get_split_char(&config), ' ');
+    }
+
+    #[test]
+    fn test_escape_string() {
+        assert_eq!(super::escape_string("normal"), "normal");
+        assert_eq!(super::escape_string("quote \""), "quote \\\"");
+        assert_eq!(super::escape_string("backslash \\"), "backslash \\\\");
+        assert_eq!(super::escape_string("both \" \\"), "both \\\" \\\\");
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes a potential command injection issue where window titles could influence workspace renaming commands. It escapes double quotes and backslashes in workspace names.

---

Copilot Summary:

This pull request improves the reliability of workspace renaming by ensuring that special characters in workspace names are properly escaped when generating rename commands. Additionally, it introduces unit tests to verify the escaping logic.

**Workspace renaming reliability:**

* Added a new helper function `escape_string` in `src/lib.rs` to correctly escape backslashes and double quotes in workspace names.
* Updated the workspace renaming command in `update_tree` to use `escape_string` for both old and new workspace names, preventing malformed commands when names contain special characters.

**Testing improvements:**

* Added unit tests for `escape_string` in the test module of `src/lib.rs` to ensure correct escaping of normal strings, quotes, backslashes, and combinations thereof.